### PR TITLE
Add radial mind map website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# test_project_codex
+# Dhruv Mind Map
+
+A minimal website showcasing a radial design thinking mind map with Dhruv at the center.
+
+## Running locally
+
+1. Install dependencies and start a static server:
+   ```bash
+   npm start
+   ```
+2. Open <http://localhost:8080> in your browser.
+
+Open `index.html` in a web browser to explore branches for projects, skills, tools, collaborations, insights and research.
+Click any node to zoom and, where available, open related content.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dhruv – Everything is connected</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+</head>
+<body>
+  <svg id="mindmap"></svg>
+  <script src="mindmap.js"></script>
+</body>
+</html>

--- a/mindmap.js
+++ b/mindmap.js
@@ -1,0 +1,118 @@
+const data = {
+  name: "Dhruv",
+  children: [
+    {
+      name: "Projects",
+      children: [
+        { name: "Modular Chair", type: "project", url: "#" },
+        { name: "Sustainable Lamp", type: "project", url: "#" }
+      ]
+    },
+    {
+      name: "Skills",
+      children: [
+        { name: "Sketching", type: "reflection", url: "#" },
+        { name: "3D Modeling", type: "video", url: "#" }
+      ]
+    },
+    {
+      name: "Tools",
+      children: [
+        { name: "Fusion 360", type: "video", url: "#" },
+        { name: "Arduino", type: "project", url: "#" }
+      ]
+    },
+    {
+      name: "Collaborations",
+      children: [
+        { name: "Team Alpha", type: "project", url: "#" },
+        { name: "Craft Collective", type: "reflection", url: "#" }
+      ]
+    },
+    {
+      name: "Insights",
+      children: [
+        { name: "Material Exploration", type: "reflection", url: "#" },
+        { name: "User Empathy", type: "video", url: "#" }
+      ]
+    },
+    {
+      name: "Research",
+      children: [
+        { name: "Ergonomics Study", type: "project", url: "#" },
+        { name: "Sustainability Trends", type: "reflection", url: "#" }
+      ]
+    }
+  ]
+};
+
+const width = window.innerWidth;
+const height = window.innerHeight;
+const radius = Math.min(width, height) / 2;
+
+const tree = d3.tree().size([2 * Math.PI, radius - 100]);
+const root = d3.hierarchy(data);
+tree(root);
+
+const svg = d3.select("#mindmap")
+  .attr("width", width)
+  .attr("height", height);
+
+const g = svg.append("g");
+
+const zoom = d3.zoom().on("zoom", (event) => {
+  g.attr("transform", event.transform);
+});
+
+svg.call(zoom).call(zoom.transform, d3.zoomIdentity.translate(width / 2, height / 2));
+
+const link = g.append("g")
+  .attr("fill", "none")
+  .attr("stroke", "#555")
+  .attr("stroke-opacity", 0.4)
+  .attr("stroke-width", 1.5)
+  .selectAll("path")
+  .data(root.links())
+  .join("path")
+  .attr("d", d3.linkRadial()
+    .angle(d => d.x)
+    .radius(d => d.y)
+  );
+
+const node = g.append("g")
+  .selectAll("g")
+  .data(root.descendants())
+  .join("g")
+  .attr("class", "node")
+  .attr("transform", d => `rotate(${d.x * 180 / Math.PI - 90}) translate(${d.y},0)`);
+
+node.append("circle")
+  .attr("r", 4)
+  .attr("fill", d => {
+    if (!d.parent) return "#ff8c00"; // center node
+    if (d.children) return "#ffce00"; // category nodes
+    return d.data.type === "video" ? "#4ecdc4" :
+           d.data.type === "reflection" ? "#1a535c" : "#ff6b6b";
+  });
+
+node.append("text")
+  .attr("dy", "0.31em")
+  .attr("x", d => d.x < Math.PI === !d.children ? 6 : -6)
+  .attr("text-anchor", d => d.x < Math.PI === !d.children ? "start" : "end")
+  .attr("transform", d => d.x >= Math.PI ? "rotate(180)" : null)
+  .text(d => d.data.name);
+
+function radialPoint(x, y) {
+  return [y * Math.cos(x - Math.PI / 2), y * Math.sin(x - Math.PI / 2)];
+}
+
+node.on("click", (event, d) => {
+  const [x, y] = radialPoint(d.x, d.y);
+  svg.transition().duration(750)
+    .call(zoom.transform,
+      d3.zoomIdentity.translate(width / 2, height / 2).scale(2).translate(-x, -y));
+  if (!d.children && d.data.url) {
+    setTimeout(() => window.open(d.data.url, "_blank"), 750);
+  }
+});
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "mindmap-site",
+  "version": "1.0.0",
+  "description": "Radial mind map website",
+  "scripts": {
+    "start": "python3 -m http.server 8080",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "dependencies": {}
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,21 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #f9f9f9;
+}
+
+#mindmap {
+  width: 100vw;
+  height: 100vh;
+}
+
+.node circle {
+  cursor: pointer;
+  stroke: #555;
+  stroke-width: 1px;
+}
+
+.node text {
+  font-size: 12px;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Create index.html loading D3 and project scripts
- Add D3-based mind map with branches for projects, skills, tools, collaborations, insights, and research with zoom and link support
- Style layout for full-screen SVG and interactive nodes
- Add package.json with local server and test scripts
- Document how to run the site locally

## Testing
- `npm test`
- `python3 -m http.server 8080` *(served index.html)*

------
https://chatgpt.com/codex/tasks/task_e_6895ce4b3ca483338c228dc41e65616a